### PR TITLE
fix: css padding rule in class 'div.relative.py-10'

### DIFF
--- a/examples/demo/package.json
+++ b/examples/demo/package.json
@@ -18,8 +18,9 @@
 		"@react-zero-ui/core": "^0.1.0",
 		"@vercel/analytics": "^1.5.0",
 		"clsx": "^2.1.1",
+		"framer-motion": "^12.19.2",
 		"motion": "^12.16.0",
-		"next": "15.3.3",
+		"next": "^15.3.4",
 		"react": "^19.0.0",
 		"react-dom": "^19.0.0"
 	},

--- a/examples/demo/src/app/(test)/layout.css
+++ b/examples/demo/src/app/(test)/layout.css
@@ -1,3 +1,0 @@
-div.relative.py-10{
-    padding: 0;
-}

--- a/examples/demo/src/app/(test)/layout.css
+++ b/examples/demo/src/app/(test)/layout.css
@@ -1,0 +1,3 @@
+div.relative.py-10{
+    padding: 0;
+}

--- a/examples/demo/src/app/(test)/layout.tsx
+++ b/examples/demo/src/app/(test)/layout.tsx
@@ -1,7 +1,6 @@
 'use client';
 import { domAnimation, LazyMotion } from 'motion/react';
 import { RenderTracker } from './ReactTracker';
-import './layout.css'
 
 const layout: React.FC<{ children: React.ReactNode }> = ({ children }) => {
 	return (

--- a/examples/demo/src/app/(test)/layout.tsx
+++ b/examples/demo/src/app/(test)/layout.tsx
@@ -1,5 +1,7 @@
+'use client';
 import { domAnimation, LazyMotion } from 'motion/react';
 import { RenderTracker } from './ReactTracker';
+import './layout.css'
 
 const layout: React.FC<{ children: React.ReactNode }> = ({ children }) => {
 	return (

--- a/examples/demo/src/app/globals.css
+++ b/examples/demo/src/app/globals.css
@@ -6,7 +6,9 @@
 		0px 2px 2px -1.5px rgba(0, 0, 0, 0.32), 0px 4.4px 4.4px -2.25px rgba(0, 0, 0, 0.3), 0px 9.8px 9.8px -3px rgba(0, 0, 0, 0.25),
 		0px 25px 25px -3.75px rgba(0, 0, 0, 0.11), 0px -5px 5px -3.75px rgba(0, 0, 0, 0.11);
 }
-
+div.relative.py-10{
+    padding: 0;
+}
 /* * {
 	border: 1px dotted red;
 } */


### PR DESCRIPTION
## Summary
"Closes #10"
Unnecessary css rule padding-top and padding-bottom set to 0px so that the UI will display correctly when scrolling
<!-- Briefly describe the purpose of this PR and what it changes. If fixing an issue, reference it with "Closes #123". -->

---

## Type of Change

<!-- Select one or more by replacing `[ ]` with `[x]` -->

- [x] 🛠 Refactor

---

## Checklist

- [x] All tests pass (`pnpm test`)
- [x] Linting and formatting pass (`pnpm lint && pnpm format`)
- [x] PR title follows semantic commit format (`feat:`, `fix:`, etc.)
- [x] Changes are documented (README, JSDoc, or comments if needed)
- [x] Ready for review — not a draft

---

## Notes for Reviewer
Made without tailwind manipulations, but with pure css fix
<!-- Optional: Anything specific you'd like feedback on, or explain complex decisions here. -->
